### PR TITLE
fix: 移除重复的Header组件

### DIFF
--- a/app/(saas)/create/layout.tsx
+++ b/app/(saas)/create/layout.tsx
@@ -1,7 +1,6 @@
 import type React from 'react';
 
 import { Analytics } from '@vercel/analytics/react';
-import { Header } from '@/components/Header';
 import { LoginModal } from '@/app/app-components/Login';
 
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -11,7 +10,6 @@ import { AlertToast } from '@/components/AlertToast';
 export default function CreateLayout({ children }: { children: React.ReactNode }) {
   return (
     <TooltipProvider>
-      <Header />
       <div className="flex-1">
         {children}
       </div>


### PR DESCRIPTION
- 删除(saas)/create/layout.tsx中重复的Header渲染
- 解决create页面显示双重导航栏的问题
- 保持ConditionalHeader的统一管理逻辑