### PR TITLE
feat: 实现营销页面demo-thumb点击跳转功能

### DIFF
--- a/src/components/client/DemoThumbnail.tsx
+++ b/src/components/client/DemoThumbnail.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+interface DemoThumbnailProps {
+  imageSrc: string;
+  index: number;
+  title: string;
+  saasUrl: string;
+}
+
+export default function DemoThumbnail({ imageSrc, index, title, saasUrl }: DemoThumbnailProps) {
+  const router = useRouter();
+
+  const handleDemoClick = () => {
+    router.push(saasUrl);
+  };
+
+  return (
+    <div 
+      key={index} 
+      className="demo-thumb"
+      onClick={handleDemoClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          handleDemoClick();
+        }
+      }}
+    >
+      <Image
+        src={imageSrc}
+        alt={`Demo image ${index + 1} for ${title}`}
+        width={50}
+        height={50}
+        className="demo-img"
+      />
+    </div>
+  );
+}

--- a/src/components/server/StaticHeroMain.tsx
+++ b/src/components/server/StaticHeroMain.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { ThemeConfig } from '../../types/theme';
 import HeroSliderDrag from '../client/HeroSliderDrag';
+import DemoThumbnail from '../client/DemoThumbnail';
 
 interface StaticHeroMainProps {
   theme: ThemeConfig;
@@ -366,15 +367,13 @@ export default function StaticHeroMain({ theme, saasUrl, isHomepage = false }: S
 No image? Try one of these:</p>
             <div className="demo-thumbnails">
               {heroMain.demoImages.map((imageSrc, index) => (
-                <div key={index} className="demo-thumb">
-                  <Image
-                    src={imageSrc}
-                    alt={`Demo image ${index + 1} for ${heroMain.title}`}
-                    width={50}
-                    height={50}
-                    className="demo-img"
-                  />
-                </div>
+                <DemoThumbnail 
+                  key={index}
+                  imageSrc={imageSrc}
+                  index={index}
+                  title={heroMain.title}
+                  saasUrl={saasUrl}
+                />
               ))}
             </div>
           </div>

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -36,15 +36,15 @@ export function getRouteByTheme(themeId: string): string {
 
 // 路由到SaaS URL的映射
 export const routeToSaasUrlMap: Record<string, string> = {
-  'image-background-remover': 'https://www.creamoda.ai/fashion-design/create',
-  'image-background-changer': 'https://www.creamoda.ai/fashion-design/create',
-  'image-enhancer': 'https://www.creamoda.ai/fashion-design/create',
-  'image-changer': 'https://www.creamoda.ai/fashion-design/create',
-  'image-color-changer': 'https://www.creamoda.ai/fashion-design/create',
-  'virtual-try-on': 'https://www.creamoda.ai/fashion-design/create',
+  'image-background-remover': 'https://www.creamoda.ai/magic-kit/create',
+  'image-background-changer': 'https://www.creamoda.ai/magic-kit/create', 
+  'image-enhancer': 'https://www.creamoda.ai/magic-kit/create',
+  'image-changer': 'https://www.creamoda.ai/magic-kit/create',
+  'image-color-changer': 'https://www.creamoda.ai/magic-kit/create',
+  'virtual-try-on': 'https://www.creamoda.ai/virtual-try-on/create',
   'outfit-generator': 'https://www.creamoda.ai/fashion-design/create',
   'sketch-to-image': 'https://www.creamoda.ai/fashion-design/create',
-  'free-nano-banana': 'https://www.creamoda.ai/fashion-design/create'
+  'free-nano-banana': 'https://www.creamoda.ai/magic-kit/create'
 };
 
 // 根据路由获取SaaS URL


### PR DESCRIPTION
- 更新路由配置，设置不同营销页面对应的SaaS功能页面：
  - sketch-to-image, outfit-generator → /fashion-design/create
  - virtual-try-on → /virtual-try-on/create
  - image-background-remover等5个图片工具 → /magic-kit/create
- 创建DemoThumbnail客户端组件，支持点击跳转和键盘访问
- 修改StaticHeroMain组件，使用可交互的DemoThumbnail替代静态组件